### PR TITLE
Fix a missing dependency to avoid failure on the first run

### DIFF
--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -152,6 +152,7 @@ class unbound::config::server {
       command => "wget -q ${::unbound::root_hints_url} -O ${root_hints}",
       user    => $::unbound::user,
       creates => $root_hints,
+      before  => File["${::unbound::config_sub_dir}/server.conf"],
     }
   }
 
@@ -160,6 +161,7 @@ class unbound::config::server {
       command => "unbound-anchor -a ${auto_trust_anchor_file}",
       user    => $::unbound::user,
       creates => $auto_trust_anchor_file,
+      before  => File["${::unbound::config_sub_dir}/server.conf"],
     }
   }
 }


### PR DESCRIPTION
Here is what happen if I declare the ``unbound`` class for the first time on a node:

```
Info: /Stage[main]/Unbound::Config/File[/etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf]: Filebucketed /etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf to puppet with sum a6c8d76007c5c6311d52e39735727676
Notice: /Stage[main]/Unbound::Config/File[/etc/unbound/unbound.conf.d/root-auto-trust-anchor-file.conf]/ensure: removed
Error: Execution of 'unbound-checkconf /etc/unbound/unbound.conf.d/server.conf20171105-708-ey7rts' returned 1: /var/lib/unbound/root.hints: No such file or directory
[1509900190] unbound-checkconf[1373:0] fatal error: file with root-hints: "/var/lib/unbound/root.hints" does not exist
Error: /Stage[main]/Unbound::Config::Server/File[/etc/unbound/unbound.conf.d/server.conf]/ensure: change from absent to file failed: Execution of 'unbound-checkconf /etc/unbound/unbound.conf.d/server.conf20171105-708-ey7rts' returned 1: /var/lib/unbound/root.hints: No such file or directory
[1509900190] unbound-checkconf[1373:0] fatal error: file with root-hints: "/var/lib/unbound/root.hints" does not exist
Notice: /Stage[main]/Unbound::Config::Server/Exec[update-root-hints]/returns: executed successfully
Info: /Stage[main]/Unbound::Config::Server/Exec[update-root-hints]: Scheduling refresh of Service[unbound]
```

![capture d ecran_2017-11-05_17-58-03](https://user-images.githubusercontent.com/3330841/32417043-79a7b7d2-c253-11e7-8ef9-77c098bd3b1d.png)

Puppet tries to validate ``/etc/unbound/unbound.conf.d/server.conf`` **before** executing ``Exec[update-root-hints]``. And if ``server.conf`` contains the parameter ``root-hints: "/var/lib/unbound/root.hints"`` it fails because ``/var/lib/unbound/root.hints`` does not exist yet.

This PR fixes this behavior and forces the root.hint refresh to happen before the ``server.conf`` validation.