### PR TITLE
Fix anchoring.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -187,6 +187,6 @@ class unbound (
   contain unbound::service
 
   Class['unbound::install']
-  ~> Class['unbound::config']
-  -> Class['unbound::service']
+  -> Class['unbound::config']
+  ~> Class['unbound::service']
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arcaik-unbound",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Johan Fleury (Arcaik)",
   "summary": "Configuration and management of Unbound",
   "license": "GPL-3.0",
@@ -12,7 +12,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
Unfortunately there is a little mistake in the anchoring defined into ``init.pp``. The unbound service is never refreshed when Puppet changes the configuration files, and I suppose the ``unbound::config`` class should requires the ``unbound::install`` one (instead of being notified).

Full detail of my latest run with the issue:
![selection_005](https://user-images.githubusercontent.com/3330841/33230797-3ccb408a-d1ea-11e7-83f8-e7652060b92f.png)

I've also updated the metadata file to increase the version and added Debian 9 as supported platform (I'm running this module on it without major issue).