### PR TITLE
fix unbound::view path

### DIFF
--- a/manifests/view.pp
+++ b/manifests/view.pp
@@ -4,7 +4,8 @@ define unbound::view (
   Optional[Array[String]] $local_data = undef,
   Optional[Boolean] $stub_prime = undef,
 ) {
-  ensure_resource('::concat', "${::unbound::config_subdir}/views.conf", {
+
+  ensure_resource('::concat', "${::unbound::config_sub_dir}/views.conf", {
     ensure       => present,
     owner        => $::unbound::user,
     group        => $::unbound::group,
@@ -14,7 +15,7 @@ define unbound::view (
   })
 
   ::concat::fragment { "view-${title}.conf":
-    target  => "${::unbound::config_subdir}/views.conf",
+    target  => "${::unbound::config_sub_dir}/views.conf",
     content => template('unbound/view.conf.erb'),
   }
 }


### PR DESCRIPTION
- unbound::config_sub_dir was referenced wrongly as
  unbound::config_subdir
- concat as resource fails if referenced with ::concat