### PR TITLE
allow to set username distinct from file owner (user)

### DIFF
--- a/manifests/config/server.pp
+++ b/manifests/config/server.pp
@@ -59,7 +59,7 @@ class unbound::config::server {
   $access_control_tag_data = $::unbound::access_control_tag_data
   $access_control_view = $::unbound::access_control_view
   $chroot = $::unbound::chroot
-  $username = $::unbound::user
+  $username = $::unbound::username
   $directory = $::unbound::directory
   $logfile = $::unbound::logfile
   $use_syslog = $::unbound::use_syslog

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,7 @@ class unbound (
   Stdlib::AbsolutePath $config_sub_dir = $::unbound::params::config_sub_dir,
 
   String $user = $::unbound::params::user,
+  String $username = $::unbound::params::user,
   String $group = $::unbound::params::group,
 
   String $validate_cmd = $::unbound::params::validate_cmd,


### PR DESCRIPTION
the default value (unbound) is kept the same for both.